### PR TITLE
[Layout]Rework Partials, Index and Single Page Layout

### DIFF
--- a/themes/reactos/layouts/index.html
+++ b/themes/reactos/layouts/index.html
@@ -1,20 +1,21 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-  {{ partial "head.html" . }}
+{{ partial "head.html" . }}
 
-  <body>
+<body>
+    
     {{ partial "banner.html" . }}
 
-    <div id="all">
+    <header>
 
-        <header>
+        {{ partial "top.html" . }}
 
-          {{ partial "top.html" . }}
+        {{ partial "nav.html" . }}
 
-          {{ partial "nav.html" . }}
+    </header>
 
-        </header>
+    <div class="container-fluid">
 
         {{ partial "carousel.html" . }}
 
@@ -31,9 +32,9 @@
         {{ partial "footer.html" . }}
 
     </div>
-    <!-- /#all -->
+    <!-- /.container-fluid -->
 
     {{ partial "scripts.html" . }}
 
-  </body>
+</body>
 </html>

--- a/themes/reactos/layouts/page/single.html
+++ b/themes/reactos/layouts/page/single.html
@@ -1,56 +1,50 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-  {{ partial "head.html" . }}
+	{{ partial "head.html" . }}
 
-  <body>
+	<body>
+  
     {{ partial "banner.html" . }}
 
-    <div id="all">
+    <header>
 
-        <header>
+        {{ partial "nav.html" . }}
 
-          {{ partial "nav.html" . }}
-
-        </header>
+    </header>
+		
+	<div id="container-fluid">
 
         {{ partial "breadcrumbs.html" . }}
+			 
+		<div class="row">
+			
+			<div class="col-md-12">
 
-        <div id="content">
-            {{ if isset .Params "id" }}
+			{{ if isset .Params "id" }}
 
-              {{ partial .Params.id . }}
+				{{ partial .Params.id . }}
 
-            {{ else }}
+			{{ else }}
 
-            <div class="container">
-
-                <div class="row">
-
-                    <div class="col-md-12">
-
-                        <div>
-                          {{ .Content }}
-                        </div>
-
-                    </div>
-
-                </div>
-                <!-- /.row -->
-
-            </div>
-            <!-- /.container -->
-
-            {{ end }}
-        </div>
-        <!-- /#content -->
-
-        {{ partial "footer.html" . }}
+				{{ .Content }}
+				
+			{{ end }}
+                        
+			</div>
+			<!-- /.col-md-12 -->
+				
+		</div>
+        <!-- /.row -->
+			
+		{{ partial "footer.html" . }}
 
     </div>
-    <!-- /#all -->
+	<!-- /#container-fluid -->
+		
 
-    {{ partial "scripts.html" . }}
+		
+	{{ partial "scripts.html" . }}
 
-  </body>
+ </body>
 </html>

--- a/themes/reactos/layouts/page/single.html
+++ b/themes/reactos/layouts/page/single.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-	{{ partial "head.html" . }}
+{{ partial "head.html" . }}
 
-	<body>
-  
+<body>
+
     {{ partial "banner.html" . }}
 
     <header>
@@ -12,39 +12,37 @@
         {{ partial "nav.html" . }}
 
     </header>
-		
-	<div id="container-fluid">
+
+    <div id="container-fluid">
 
         {{ partial "breadcrumbs.html" . }}
-			 
-		<div class="row">
-			
-			<div class="col-md-12">
 
-			{{ if isset .Params "id" }}
+        <div class="row">
+            
+            <div class="col-md-12">
 
-				{{ partial .Params.id . }}
+            {{ if isset .Params "id" }}
 
-			{{ else }}
+                {{ partial .Params.id . }}
 
-				{{ .Content }}
-				
-			{{ end }}
-                        
-			</div>
-			<!-- /.col-md-12 -->
-				
-		</div>
+            {{ else }}
+
+                {{ .Content }}
+
+            {{ end }}
+
+            </div>
+            <!-- /.col-md-12 -->
+
+        </div>
         <!-- /.row -->
-			
-		{{ partial "footer.html" . }}
+
+        {{ partial "footer.html" . }}
 
     </div>
-	<!-- /#container-fluid -->
-		
+    <!-- /#container-fluid -->
 
-		
-	{{ partial "scripts.html" . }}
+    {{ partial "scripts.html" . }}
 
- </body>
+</body>
 </html>

--- a/themes/reactos/layouts/partials/breadcrumbs.html
+++ b/themes/reactos/layouts/partials/breadcrumbs.html
@@ -1,21 +1,18 @@
-<div id="heading-breadcrumbs">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                    {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
-                    {{ $.Scratch.Add "path" .Site.BaseURL }}
-                    <div class="breadcrumbs">
-                      <a href="{{ .Site.BaseURL }}">home</a>
-                      {{ range $index, $element := split $url "/" }}
-                        {{ $.Scratch.Add "path" $element }}
-                          {{ if ne $element "" }}
-                          / <a href='{{ $.Scratch.Get "path" }}'>{{ . }}</a>
-                          {{ $.Scratch.Add "path" "/" }}
-                          {{ end }}
-                      {{ end }}
-                    </div>
-                <h1>{{ .Title }}</h1>
+<div class="row" id="heading-breadcrumbs">
+    <div class="col-md-12">
+            {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
+            {{ $.Scratch.Add "path" .Site.BaseURL }}
+            <div class="breadcrumbs">
+              <a href="{{ .Site.BaseURL }}">home</a>
+              {{ range $index, $element := split $url "/" }}
+                {{ $.Scratch.Add "path" $element }}
+                  {{ if ne $element "" }}
+                  / <a href='{{ $.Scratch.Get "path" }}'>{{ . }}</a>
+                  {{ $.Scratch.Add "path" "/" }}
+                  {{ end }}
+              {{ end }}
             </div>
-        </div>
+        <h1>{{ .Title }}</h1>
     </div>
 </div>
+

--- a/themes/reactos/layouts/partials/carousel.html
+++ b/themes/reactos/layouts/partials/carousel.html
@@ -1,28 +1,24 @@
 {{ if isset .Site.Params "carousel" }}
 {{ if .Site.Params.carousel.enable }}
 {{ if gt (len .Site.Data.carousel) 0 }}
-<section>
-    <div class="home-carousel">
-        <div class="dark-mask"></div>
-        <div class="container">
-            <div class="homepage owl-carousel">
-                {{ range sort .Site.Data.carousel "weight" }}
-                <div class="item">
-                    <div class="row">
-                        <div class="col-sm-5 right">
-                            <h1>{{ .title }}</h1>
-                            {{ .description | safeHTML }}
-                        </div>
-                        <div class="col-sm-7">
-                            <img class="img-responsive" src="{{ .image }}" alt="">
-                        </div>
-                    </div>
+<section class="row home-carousel">
+
+    <div class="col-sm-12 homepage owl-carousel">
+
+        {{ range sort .Site.Data.carousel "weight" }}
+        <div class="row item">
+                <div class="col-sm-5 right">
+                    <h1>{{ .title }}</h1>
+                    {{ .description | safeHTML }}
                 </div>
-                {{ end }}
-            </div>
-            <!-- /.project owl-slider -->
+                <div class="col-sm-7">
+                    <img class="img-responsive" src="{{ .image }}" alt="">
+                </div>
         </div>
+        {{ end }}
+
     </div>
+
 </section>
 {{ end }}
 {{ end }}

--- a/themes/reactos/layouts/partials/carousel.html
+++ b/themes/reactos/layouts/partials/carousel.html
@@ -1,28 +1,24 @@
 {{ if isset .Site.Params "carousel" }}
 {{ if .Site.Params.carousel.enable }}
 {{ if gt (len .Site.Data.carousel) 0 }}
-<section>
-    <div class="home-carousel">
-        <div class="dark-mask"></div>
-        <div class="container">
-            <div class="homepage owl-carousel">
-                {{ range sort .Site.Data.carousel "weight" }}
-                <div class="item">
-                    <div class="row">
-                        <div class="col-sm-5 right">
-                            <h1>{{ .title }}</h1>
-                            {{ .description | safeHTML }}
-                        </div>
-                        <div class="col-sm-7">
-                            <img class="img-responsive" src="{{ .image }}" alt="">
-                        </div>
-                    </div>
+<section class="row home-carousel">
+
+    <div class="col-sm-12 homepage owl-carousel">
+
+        {{ range sort .Site.Data.carousel "weight" }}
+        <div class="row item">
+                <div class="col-sm-5 right">
+                    <h1>{{ .title }}</h1>
+                    {{ .description | safeHTML }}
                 </div>
-                {{ end }}
-            </div>
-            <!-- /.project owl-slider -->
+                <div class="col-sm-7">
+                    <img class="img-responsive" src="{{ .image }}" alt="">
+                </div>
         </div>
+        {{ end }}
+
     </div>
+    <div class="dark-mask"></div>
 </section>
 {{ end }}
 {{ end }}

--- a/themes/reactos/layouts/partials/carousel.html
+++ b/themes/reactos/layouts/partials/carousel.html
@@ -1,24 +1,28 @@
 {{ if isset .Site.Params "carousel" }}
 {{ if .Site.Params.carousel.enable }}
 {{ if gt (len .Site.Data.carousel) 0 }}
-<section class="row home-carousel">
-
-    <div class="col-sm-12 homepage owl-carousel">
-
-        {{ range sort .Site.Data.carousel "weight" }}
-        <div class="row item">
-                <div class="col-sm-5 right">
-                    <h1>{{ .title }}</h1>
-                    {{ .description | safeHTML }}
+<section>
+    <div class="home-carousel">
+        <div class="dark-mask"></div>
+        <div class="container">
+            <div class="homepage owl-carousel">
+                {{ range sort .Site.Data.carousel "weight" }}
+                <div class="item">
+                    <div class="row">
+                        <div class="col-sm-5 right">
+                            <h1>{{ .title }}</h1>
+                            {{ .description | safeHTML }}
+                        </div>
+                        <div class="col-sm-7">
+                            <img class="img-responsive" src="{{ .image }}" alt="">
+                        </div>
+                    </div>
                 </div>
-                <div class="col-sm-7">
-                    <img class="img-responsive" src="{{ .image }}" alt="">
-                </div>
+                {{ end }}
+            </div>
+            <!-- /.project owl-slider -->
         </div>
-        {{ end }}
-
     </div>
-
 </section>
 {{ end }}
 {{ end }}

--- a/themes/reactos/layouts/partials/footer.html
+++ b/themes/reactos/layouts/partials/footer.html
@@ -1,74 +1,76 @@
-<footer id="footer">
-    <div class="container">
+<footer class="row" id="footer" >
+		
+	<div class="col-sm-12">
 
-        {{ if isset .Site.Params "about_us" }}
-        <div class="col-md-4 col-sm-6">
-            <h4>{{ i18n "aboutUs" }}</h4>
-
-            {{ .Site.Params.about_us | markdownify }}
-
-            <hr class="hidden-md hidden-lg hidden-sm">
-
-        </div>
-        <!-- /.col-md-4 -->
-        {{ end }}
-
-        <div class="col-md-4 col-sm-6">
-
-            {{ if isset .Site.Params "recent_posts" }} {{ if .Site.Params.recent_posts.enable }}
-            <h4>{{ i18n "recentPosts" }}</h4>
-
-            <div class="blog-entries">
-                {{ range first 3 (where .Site.Pages "Type" "in" (slice "project-news" "blogs")) }}
-                <div class="item same-height-row clearfix">
-                    <div class="image same-height-always">
-                        <a href="{{ .Permalink }}">
-                          {{ if isset .Params "banner" }}
-                            <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="{{ .Title }}">
-                          {{ else }}
-                            <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="{{ .Title }}">
-                          {{ end }}
-                        </a>
-                    </div>
-                    <div class="name same-height-always">
-                        <h5><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
-                    </div>
-                </div>
-                {{ end }}
-            </div>
-
-            <hr class="hidden-md hidden-lg">
-            {{ end }} {{ end }}
-
-        </div>
-        <!-- /.col-md-4 -->
-
-    </div>
-    <!-- /.container -->
+		<div class="row">
+		
+			{{ if isset .Site.Params "about_us" }}
+			<div class="col-md-4 col-sm-6">
+				<h4>{{ i18n "aboutUs" }}</h4>
+		
+				{{ .Site.Params.about_us | markdownify }}
+		
+				<hr class="hidden-md hidden-lg hidden-sm">
+		
+			</div>
+			<!-- /.col-md-4 -->	
+			{{ end }}
+		
+			<div class="col-md-4 col-sm-6">
+				{{ if isset .Site.Params "recent_posts" }} {{ if .Site.Params.recent_posts.enable }}
+				<h4>{{ i18n "recentPosts" }}</h4>
+		
+				<div class="blog-entries">
+					{{ range first 3 (where .Site.Pages "Type" "in" (slice "project-news" "blogs")) }}
+					<div class="item same-height-row clearfix">
+						<div class="image same-height-always">
+							<a href="{{ .Permalink }}">
+								{{ if isset .Params "banner" }}
+								<img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="{{ .Title }}">
+								{{ else }}
+								<img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="{{ .Title }}">
+								{{ end }}
+							</a>
+						</div>
+						<div class="name same-height-always">
+							<h5><a href="{{ .Permalink }}">{{ .Title }}</a></h5>
+						</div>
+					</div>
+				{{ end }}
+				</div>	
+				<hr class="hidden-md hidden-lg">
+				{{ end }} {{ end }}		
+			</div>
+			<!-- /.col-md-4 -->
+			
+		</div>
+		<!-- /.row -->
+		
+		<!-- *** COPYRIGHT ***-->
+		<div class="row" id="copyright">
+		
+			<div class="col-md-12">
+				{{ if isset .Site.Params "copyright" }}
+				<p class="pull-left">{{ .Site.Params.copyright | safeHTML }}</p>
+				{{ end }}
+				<p class="pull-right">
+				{{ i18n "templateBy" }} <a href="http://bootstrapious.com/free-templates">Bootstrapious</a>.
+				<!-- Not removing this link is part of the licence conditions of the template. Thanks for understanding :) -->
+		
+				{{ i18n "portedBy" }} <a href="https://github.com/devcows/hugo-universal-theme">DevCows</a>
+				</p>
+			</div>
+			
+		</div>
+		<!-- /.row -->
+		<!-- *** COPYRIGHT END *** -->
+		
+	</div>
+	<!--/.col-sm-12-->
+	
 </footer>
-
 <!-- /#footer -->
-
 <!-- *** FOOTER END *** -->
 
-<!-- *** COPYRIGHT ***
-_________________________________________________________ -->
 
-<div id="copyright">
-    <div class="container">
-        <div class="col-md-12">
-            {{ if isset .Site.Params "copyright" }}
-            <p class="pull-left">{{ .Site.Params.copyright | safeHTML }}</p>
-            {{ end }}
-            <p class="pull-right">
-              {{ i18n "templateBy" }} <a href="http://bootstrapious.com/free-templates">Bootstrapious</a>.
-              <!-- Not removing this link is part of the licence conditions of the template. Thanks for understanding :) -->
 
-              {{ i18n "portedBy" }} <a href="https://github.com/devcows/hugo-universal-theme">DevCows</a>
-            </p>
-        </div>
-    </div>
-</div>
-<!-- /#copyright -->
-
-<!-- *** COPYRIGHT END *** -->

--- a/themes/reactos/layouts/partials/recent_posts.html
+++ b/themes/reactos/layouts/partials/recent_posts.html
@@ -1,68 +1,69 @@
 {{ if isset .Site.Params "recent_posts" }}
 {{ if .Site.Params.recent_posts.enable }}
-<section class="bar background-white no-mb">
-    <div class="container">
+<section class="row bar background-white no-mb">
 
-        <div class="col-md-12">
+    <div class="col-md-8 col-md-offset-2">
+    
+        <div class="row">
             <div class="heading text-center">
                 <h2>{{ .Site.Params.recent_posts.title }}</h2>
             </div>
-
+    
             <p class="lead">
-              {{ .Site.Params.recent_posts.subtitle | markdownify }}
+            {{ .Site.Params.recent_posts.subtitle | markdownify }}
             </p>
+        </div>
+        <!-- /.row -->
+        
+        <!-- *** BLOG HOMEPAGE *** -->
 
-            <!-- *** BLOG HOMEPAGE *** -->
+        <div class="row">
 
-            <div class="row">
-
-                {{ $posts := .Paginate (where .Data.Pages "Type" "in" (slice "project-news" "blogs")) }}
-                {{ range first 4 $posts.Pages }}
-                <div class="col-md-3 col-sm-6">
-                    <div class="box-image-text blog">
-                        <div class="top">
-                            <div class="image" style="overflow:hidden">
-                                {{ if isset .Params "banner" }}
-                                <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="" >
-                                {{ else }}
-                                <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
-                                {{ end }}
-                            </div>
-                            <div class="bg"></div>
-                            <div class="text">
-                                <p class="buttons">
-                                    <a href="{{ .Permalink }}" class="btn btn-template-transparent-primary"><i class="fa fa-link"></i> {{ i18n "readMore" }}</a>
-                                </p>
-                            </div>
-                        </div>
-
-                        <div class="content">
-                            <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
-                            <p class="author-category">
-                            {{ with .Params.author }}
-                            {{ i18n "authorBy" }} <a href="#">{{ . }}</a>
+            {{ $posts := .Paginate (where .Data.Pages "Type" "in" (slice "project-news" "blogs")) }}
+            {{ range first 4 $posts.Pages }}
+            <div class="col-md-3 col-sm-6">
+                <div class="box-image-text blog">
+                    <div class="top">
+                        <div class="image" style="overflow:hidden">
+                            {{ if isset .Params "banner" }}
+                            <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="" >
+                            {{ else }}
+                            <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
                             {{ end }}
-                            {{ i18n "publishedOn" }} {{ .Date.Format .Site.Params.date_format }}
-                            </p>
-                            <p class="intro">{{ .Summary }}</p>
-                            <p class="read-more">
-                              <a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
+                        </div>
+                        <div class="bg"></div>
+                        <div class="text">
+                            <p class="buttons">
+                                <a href="{{ .Permalink }}" class="btn btn-template-transparent-primary"><i class="fa fa-link"></i> {{ i18n "readMore" }}</a>
                             </p>
                         </div>
                     </div>
-                    <!-- /.box-image-text -->
 
+                    <div class="content">
+                        <h4><a href="{{ .Permalink }}">{{ .Title }}</a></h4>
+                        <p class="author-category">
+                        {{ with .Params.author }}
+                        {{ i18n "authorBy" }} <a href="#">{{ . }}</a>
+                        {{ end }}
+                        {{ i18n "publishedOn" }} {{ .Date.Format .Site.Params.date_format }}
+                        </p>
+                        <p class="intro">{{ .Summary }}</p>
+                        <p class="read-more">
+                          <a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
+                        </p>
+                    </div>
                 </div>
-                {{ end }}
+                <!-- /.box-image-text -->
 
             </div>
-            <!-- /.row -->
-
-            <!-- *** BLOG HOMEPAGE END *** -->
+            {{ end }}
 
         </div>
+        <!-- /.row -->
+
+        <!-- *** BLOG HOMEPAGE END *** -->
+
     </div>
-    <!-- /.container -->
 </section>
 <!-- /.bar -->
 {{ end }}

--- a/themes/reactos/layouts/partials/see_more.html
+++ b/themes/reactos/layouts/partials/see_more.html
@@ -1,21 +1,16 @@
 {{ if isset .Site.Params "see_more" }}
 {{ if .Site.Params.see_more.enable }}
-<section class="bar background-image-fixed-2 no-mb color-white text-center">
-    <div class="dark-mask"></div>
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <div class="icon icon-lg"><i class="{{ .Site.Params.see_more.icon }}"></i>
-                </div>
-                <h3 class="text-uppercase">{{ .Site.Params.see_more.title }}</h3>
-                <p class="lead">{{ .Site.Params.see_more.subtitle }}</p>
-                <p class="text-center">
-                    <a href="{{ .Site.Params.see_more.link_url }}" class="btn btn-template-transparent-black btn-lg">{{ .Site.Params.see_more.link_text }}</a>
-                </p>
+<section class="row bar background-image-fixed-2 no-mb color-white text-center">
+        <div class="dark-mask"></div>
+        <div class="col-md-offset-2 col-md-8">
+            <div class="icon icon-lg"><i class="{{ .Site.Params.see_more.icon }}"></i>
             </div>
-
+            <h3 class="text-uppercase">{{ .Site.Params.see_more.title }}</h3>
+            <p class="lead">{{ .Site.Params.see_more.subtitle }}</p>
+            <p class="text-center">
+                <a href="{{ .Site.Params.see_more.link_url }}" class="btn btn-template-transparent-black btn-lg">{{ .Site.Params.see_more.link_text }}</a>
+            </p>
         </div>
-    </div>
 </section>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Reworked Home page and Single.html to make them more responsive following Bootstrap design rules.
That should fix ONLINE-830 ( https://jira.reactos.org/browse/ONLINE-830 )
Rework Partials that are used by Single.html (Layout for Pages) and Index.html to avoid nested containers, and force them to start with a row class.
Clean code from Carousel to make it responsive.
More info in the commits...